### PR TITLE
Fix npx execution by adding bin field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "mcp-graphql-schema",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "sideEffects": false,
   "main": "index.mjs",
+  "bin": {
+    "mcp-graphql-schema": "index.mjs"
+  },
   "description": "Model Context Protocol server for GraphQL schemas",
   "keywords": [
     "mcp",


### PR DESCRIPTION
This PR addresses issue #1 where users are seeing "could not determine executable to run" errors when trying to use the package with npx.

Changes:
- Added a "bin" field to package.json that points to index.mjs as the executable
- Bumped version from 0.0.1 to 0.0.2

The index.mjs file already has the proper shebang line (#!/usr/bin/env node), so it's ready to be used as an executable. This change will allow users to properly run the package using npx without having to clone the repository.

After merging, it would be great if you could publish a new version to npm so users can benefit from this fix.